### PR TITLE
Button for restart makes more sense than a switch

### DIFF
--- a/waterp1meterkit-v2/waterp1meterkit-ethernet.yaml
+++ b/waterp1meterkit-v2/waterp1meterkit-ethernet.yaml
@@ -43,10 +43,10 @@ ethernet:
 web_server:
   port: 80
 
-# Switch to restart the waterp1meter
-switch:
+# Button to restart the waterp1meter
+button:
   - platform: restart
-    id: switch_restart
+    id: button_restart
     name: "${friendly_name} Restart"
 
 # I²C Bus

--- a/waterp1meterkit-v2/waterp1meterkit-wifi.yaml
+++ b/waterp1meterkit-v2/waterp1meterkit-wifi.yaml
@@ -47,10 +47,10 @@ captive_portal:
 web_server:
   port: 80
 
-# Switch to restart the waterp1meter
-switch:
+# Button to restart the waterp1meter
+button:
   - platform: restart
-    id: switch_restart
+    id: button_restart
     name: "${friendly_name} Restart"
 
 # I²C Bus


### PR DESCRIPTION
Changes restart option to button instead of switch. Makes more sense to push a button for restart instead of "switch on" to restart.