### PR TITLE
Update waterp1meterkit-ethernet.yaml

### DIFF
--- a/waterp1meterkit-ethernet.yaml
+++ b/waterp1meterkit-ethernet.yaml
@@ -33,7 +33,7 @@ ethernet:
   type: LAN8720
   mdc_pin: GPIO23
   mdio_pin: GPIO18
-  clk_mode: GPIO17_OUT
+  clk: GPIO17_OUT
   phy_addr: 1
   power_pin: GPIO16
 

--- a/waterp1meterkit-ethernet.yaml
+++ b/waterp1meterkit-ethernet.yaml
@@ -33,7 +33,9 @@ ethernet:
   type: LAN8720
   mdc_pin: GPIO23
   mdio_pin: GPIO18
-  clk: GPIO17_OUT
+  clk:
+    pin: GPIO17
+    mode: CLK_OUT
   phy_addr: 1
   power_pin: GPIO16
 

--- a/waterp1meterkit-v2/waterp1meterkit-ethernet.yaml
+++ b/waterp1meterkit-v2/waterp1meterkit-ethernet.yaml
@@ -36,7 +36,9 @@ ethernet:
   type: LAN8720
   mdc_pin: GPIO23
   mdio_pin: GPIO18
-  clk_mode: GPIO17_OUT
+  clk:
+    pin: GPIO17
+    mode: CLK_OUT
   phy_addr: 1
   power_pin: GPIO33
 


### PR DESCRIPTION
Changed clk_mode to clk because of deprecation notice for ESPHome version > 2026.1

![WaterP1MeterKit warning](https://github.com/user-attachments/assets/5fb8f34f-4650-4b2b-8114-bb888978d82a)
