### PR TITLE
Ethernet clock pinout aanpassingen om incompatibiliteit bij ESPhome 2026.7.0 te voorkomen

### DIFF
--- a/waterp1meterkit-ethernet.yaml
+++ b/waterp1meterkit-ethernet.yaml
@@ -15,7 +15,9 @@ ethernet:
   type: LAN8720
   mdc_pin: GPIO23
   mdio_pin: GPIO18
-  clk_mode: GPIO17_OUT
+  clk:
+    mode: CLK_OUT
+    pin: GPIO17
   phy_addr: 1
   power_pin: GPIO16
 

--- a/waterp1meterkit-v1/eth.yaml
+++ b/waterp1meterkit-v1/eth.yaml
@@ -6,7 +6,9 @@ ethernet:
   type: LAN8720
   mdc_pin: GPIO23
   mdio_pin: GPIO18
-  clk_mode: GPIO17_OUT
+  clk:
+    mode: CLK_OUT
+    pin: GPIO17
   phy_addr: 1
   power_pin: GPIO16
 

--- a/waterp1meterkit-v2/eth.yaml
+++ b/waterp1meterkit-v2/eth.yaml
@@ -6,7 +6,9 @@ ethernet:
   type: LAN8720
   mdc_pin: GPIO23
   mdio_pin: GPIO18
-  clk_mode: GPIO17_OUT
+  clk:
+    mode: CLK_OUT
+    pin: GPIO17
   phy_addr: 1
   power_pin: GPIO33
 

--- a/waterp1meterkit-v3/eth.yaml
+++ b/waterp1meterkit-v3/eth.yaml
@@ -6,7 +6,9 @@ ethernet:
   type: LAN8720
   mdc_pin: GPIO23
   mdio_pin: GPIO18
-  clk_mode: GPIO17_OUT
+  clk:
+    mode: CLK_OUT
+    pin: GPIO17
   phy_addr: 1
   power_pin: GPIO33
 


### PR DESCRIPTION
## Samenvatting

- De ethernet clock pinout van ESPhome veranderd in 2026.7.0 onherroepelijk. Deze heb ik al eens gesubmit, maar hierbij ook toegepast op de laatste versie van waterp1meterkit
